### PR TITLE
Add scrolling optimisation needed because of mdl

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,7 @@ div#container {
   position: absolute;
   overflow-y: scroll;
   background-color: #f5f6f5;
+  will-change: transform;
 }
 
 div#main {


### PR DESCRIPTION
Fix for full screen redraw on scroll using mdl.
google/material-design-lite#828

This fix breaks some of "proper usage" points listed here:
https://developer.mozilla.org/en-US/docs/Web/CSS/will-change